### PR TITLE
change : size calculation basis for scrollbar contents from hitArea to boundsArea

### DIFF
--- a/__test__/ScrollBarContents.spec.ts
+++ b/__test__/ScrollBarContents.spec.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { ScrollBarContentsGenerator } from "./ScrollBarContentsGenerator.js";
+import { Container, Graphics, Rectangle } from "pixi.js";
+import { ScrollBarContents } from "../src/index.js";
 
 describe("ScrollBarContents", function () {
   test("init", () => {
@@ -26,5 +28,27 @@ describe("ScrollBarContents", function () {
 
     expect(contents.target.parent).toBe(contents.container);
     expect(contents.mask.parent).toBe(contents.container);
+  });
+
+  test("init with custom hitArea", () => {
+    const spyWarn = vi.spyOn(console, "warn").mockImplementation((x) => x);
+
+    const getScrollBarContents = (color: number, w: number, h: number) => {
+      const g = new Graphics().rect(0, 0, w, h).fill(color);
+      g.hitArea = new Rectangle(0, 0, w, h);
+      return g;
+    };
+
+    const contents = new ScrollBarContents(
+      getScrollBarContents(0xff00ff, 100, 100),
+      getScrollBarContents(0x0000ff, 100, 100),
+      new Container(),
+    );
+
+    expect(spyWarn).toBeCalledWith(
+      expect.stringContaining(
+        "Setting a custom hit area on scrollbar contents can lead to a mismatch between the visual area and the interactive area",
+      ),
+    );
   });
 });

--- a/__test__/ScrollBarContentsGenerator.ts
+++ b/__test__/ScrollBarContentsGenerator.ts
@@ -36,7 +36,7 @@ export class ScrollBarContentsGenerator {
    */
   private static getScrollBarContents(color: number, w: number, h: number) {
     const g = new Graphics().rect(0, 0, w, h).fill(color);
-    g.hitArea = new Rectangle(0, 0, w, h);
+    g.boundsArea = new Rectangle(0, 0, w, h);
     return g;
   }
 }

--- a/demoSrc/demo_scrollbar.js
+++ b/demoSrc/demo_scrollbar.js
@@ -1,11 +1,4 @@
-import {
-  Application,
-  Container,
-  Graphics,
-  Rectangle,
-  Ticker,
-  color32BitToUniform,
-} from "pixi.js";
+import { Application, Container, Graphics, Rectangle, Ticker } from "pixi.js";
 import { ScrollBarView, ScrollBarContents } from "../esm/index.js";
 import TWEEN from "@tweenjs/tween.js";
 

--- a/demoSrc/demo_scrollbar.js
+++ b/demoSrc/demo_scrollbar.js
@@ -1,4 +1,11 @@
-import { Application, Container, Graphics, Rectangle, Ticker } from "pixi.js";
+import {
+  Application,
+  Container,
+  Graphics,
+  Rectangle,
+  Ticker,
+  color32BitToUniform,
+} from "pixi.js";
 import { ScrollBarView, ScrollBarContents } from "../esm/index.js";
 import TWEEN from "@tweenjs/tween.js";
 
@@ -78,7 +85,7 @@ const initScrollBar = (stage, view) => {
   /**
    * スクロール動作を確認するために、故意にマスクを外しています。
    */
-  contents.target.mask = null;
+  // contents.target.mask = null;
   return scrollbar;
 };
 
@@ -99,11 +106,11 @@ const getScrollBarButton = (width, color) => {
   return g;
 };
 
-const getScrollBarContents = (color, w, h, container, alpha = 1.0) => {
+const getScrollBarContents = (w, h, container, fillStyle) => {
   const g = new Graphics();
-  g.rect(0, 0, w, h).fill({ color, alpha });
+  g.rect(0, 0, w, h).fill(fillStyle);
 
-  g.hitArea = new Rectangle(0, 0, w, h);
+  g.boundsArea = new Rectangle(0, 0, w, h);
   container.addChild(g);
   return g;
 };
@@ -115,36 +122,31 @@ const getScrollBarContents = (color, w, h, container, alpha = 1.0) => {
  */
 const overrideContents = (g, difHeight) => {
   const fill = g.fillStyle;
+  console.log(g);
   console.log(fill);
-  const hitArea = g.hitArea.clone();
-  hitArea.height += difHeight;
+
+  const area = g.boundsArea.clone();
+  area.height += difHeight;
+
   g.clear();
-  g.rect(hitArea.x, hitArea.y, hitArea.width, hitArea.height).fill({
+  g.rect(area.x, area.y, area.width, area.height).fill({
     color: fill.color,
     alpha: fill.alpha,
   });
-  g.hitArea = new Rectangle(
-    hitArea.x,
-    hitArea.y,
-    hitArea.width,
-    hitArea.height,
-  );
+  g.boundsArea = new Rectangle(area.x, area.y, area.width, area.height);
 };
 
 const getScrollBarOption = (contentsW, scrollBarH, container) => {
   const targetContents = getScrollBarContents(
-    0xff00ff,
     contentsW,
     scrollBarH * 2,
     container,
+    { color: 0xff00ff },
   );
-  const contentsMask = getScrollBarContents(
-    0x0000ff,
-    contentsW,
-    scrollBarH,
-    container,
-    0.3,
-  );
+  const contentsMask = getScrollBarContents(contentsW, scrollBarH, container, {
+    color: 0x0000ff,
+    alpha: 0.3,
+  });
   return new ScrollBarContents(targetContents, contentsMask, container);
 };
 

--- a/demoSrc/demo_scrollbar_horizontal.js
+++ b/demoSrc/demo_scrollbar_horizontal.js
@@ -73,7 +73,7 @@ const getScrollBarButton = (size, color) => {
 
 const getScrollBarContents = (color, w, h, container, alpha = 1.0) => {
   const g = new Graphics().rect(0, 0, w, h).fill({ color, alpha });
-  g.hitArea = new Rectangle(0, 0, w, h);
+  g.boundsArea = new Rectangle(0, 0, w, h);
   container.addChild(g);
   return g;
 };

--- a/src/SliderViewUtil.ts
+++ b/src/SliderViewUtil.ts
@@ -118,7 +118,12 @@ export class SliderViewUtil {
   }
 
   public static getContentsBounds(displayObj: Container): Bounds | Rectangle {
-    if (displayObj.hitArea) return displayObj.hitArea as Rectangle;
+    if (displayObj.boundsArea) {
+      return displayObj.boundsArea;
+    }
+    if (displayObj.hitArea) {
+      return displayObj.hitArea as Rectangle;
+    }
     return displayObj.getLocalBounds();
   }
 

--- a/src/scrollBar/ScrollBarContents.ts
+++ b/src/scrollBar/ScrollBarContents.ts
@@ -42,6 +42,12 @@ export class ScrollBarContents extends EventEmitter<ScrollBarContentsEventType> 
     };
     addToContainer(scrollBarContents.target);
     addToContainer(scrollBarContents.mask);
+
+    if (scrollBarContents.target.hitArea) {
+      console.warn(
+        "Setting a custom hit area on scrollbar contents can lead to a mismatch between the visual area and the interactive area, potentially causing unexpected pointer interactions. Therefore, it is recommended not to set a custom hit area on scrollbar contents. / カスタムヒットエリアがスクロールバーコンテンツに設定されていると、視覚的エリアと操作エリアが一致せず、予期しないポインター操作を引き起こす可能性があります。そのため、スクロールバーコンテンツにはカスタムヒットエリアを設定しないことを推奨します。",
+      );
+    }
   }
 
   /**

--- a/src/scrollBar/ScrollBarView.ts
+++ b/src/scrollBar/ScrollBarView.ts
@@ -42,13 +42,11 @@ export class ScrollBarView extends SliderView {
   constructor(option: SliderViewOption, scrollContents: ScrollBarContents) {
     super(option);
 
-    const initOption = SliderViewOptionUtil.init(option);
-
     this.contents = scrollContents;
     this.contents.on("changed_contents_size", this.updateSlider);
     this.sliderEventEmitter.on("slider_change", this.updateContentsPosition);
 
-    this.changeRate(initOption.rate);
+    this.changeRate(this.rate);
 
     this.wheelManager = new MouseWheelScrollManager(this);
     this.wheelManager.on("update_target_position", () => {


### PR DESCRIPTION
hitAreaとmaskを掛け合わせると、hitAreaがインタラクションで優先される。そのため、マスクで隠された範囲でもポインターイベントを奪ってしまう。

ポインターイベントに影響を与えないサイズ指定として、boundsAreaを利用する。