### PR TITLE
Add skipLibCheck option for improved type checking in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "declaration": true,
     "declarationMap": true,
     "strict": true,
-    "noImplicitOverride": true
+    "noImplicitOverride": true,
+    "skipLibCheck": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "__test__"]


### PR DESCRIPTION
Introduce the `skipLibCheck` option in the TypeScript configuration due to conflicts with pixi.js type definitions