### PR TITLE
Add enableMouseWheel option to control mouse wheel operations Changes

### DIFF
--- a/__test__/StepBarOption.spec.ts
+++ b/__test__/StepBarOption.spec.ts
@@ -21,6 +21,7 @@ describe("StepBarOption", () => {
       minValue: 0,
       step: 1,
       isHorizontal: true,
+      enableMouseWheel: true,
     });
   });
 });

--- a/__test__/StepBarView.spec.ts
+++ b/__test__/StepBarView.spec.ts
@@ -341,7 +341,7 @@ describe("StepBarView wheel", () => {
     expect(stepBar.value).toBe(30);
   });
 
-  it("should increase value on wheel up", () => {
+  it("should increase value on wheel up for reversed horizontal stepbar", () => {
     const stepBar = new StepBarView({
       ...getDefaultValue(),
       sliderStartPoint: 100,
@@ -361,7 +361,7 @@ describe("StepBarView wheel", () => {
     expect(stepBar.value).toBe(10);
   });
 
-  it("should decrease value on wheel down", () => {
+  it("should decrease value on wheel down for reversed horizontal stepbar", () => {
     const stepBar = new StepBarView({
       ...getDefaultValue(),
       sliderStartPoint: 100,
@@ -383,7 +383,7 @@ describe("StepBarView wheel", () => {
     expect(stepBar.value).toBe(20);
   });
 
-  it("should decrease value on wheel up with vertical orientation", () => {
+  it("should decrease value on wheel up with vertical stepbar", () => {
     const stepBar = new StepBarView({
       ...getDefaultValue(),
       isHorizontal: false,
@@ -393,19 +393,19 @@ describe("StepBarView wheel", () => {
     expect(stepBar.value).toBe(10);
   });
 
-  it("should increase value on wheel down with vertical orientation", () => {
+  it("should increase value on wheel up for reversed vertical stepbar", () => {
     const stepBar = new StepBarView({
       ...getDefaultValue(),
       isHorizontal: false,
-      initialValue: 20,
       sliderStartPoint: 100,
       sliderMaxPoint: 0,
+      initialValue: 20,
     });
     DummyPointerEvent.emit(base, "wheel", wheelUp);
     expect(stepBar.value).toBe(30);
   });
 
-  it("should increase value on wheel down with vertical orientation", () => {
+  it("should increase value on wheel down with vertical stepbar", () => {
     const stepBar = new StepBarView({
       ...getDefaultValue(),
       isHorizontal: false,
@@ -415,7 +415,7 @@ describe("StepBarView wheel", () => {
     expect(stepBar.value).toBe(30);
   });
 
-  it("should increase value on wheel down with vertical orientation", () => {
+  it("should decrease value on wheel down for reversed vertical stepbar", () => {
     const stepBar = new StepBarView({
       ...getDefaultValue(),
       isHorizontal: false,

--- a/__test__/StepBarView.spec.ts
+++ b/__test__/StepBarView.spec.ts
@@ -2,6 +2,7 @@ import { describe, beforeEach, expect, it, vi } from "vitest";
 import { Container, Graphics, Rectangle } from "pixi.js";
 import { StepBarView } from "../src/index.js";
 import { SliderViewTester } from "./SliderViewTester.js";
+import { DummyPointerEvent } from "./DummpyPointerEvent.js";
 
 describe("StepBarView", () => {
   let base: Container,
@@ -307,5 +308,73 @@ describe("StepBarView.base", () => {
     expect(stepBar.value).toBe(50);
     SliderViewTester.controlButton(true, base, 100, "pointermove");
     expect(stepBar.value).toBe(50);
+  });
+});
+
+describe("StepBarView wheel", () => {
+  let base: Container;
+
+  beforeEach(() => {
+    base = new Container();
+    vi.restoreAllMocks();
+  });
+
+  const getDefaultValue = () => {
+    return {
+      base,
+      sliderStartPoint: 0,
+      sliderMaxPoint: 100,
+      maxValue: 100,
+      step: 10,
+    };
+  };
+
+  it("should decrease value on wheel up", () => {
+    const stepBar = new StepBarView({
+      ...getDefaultValue(),
+      initialValue: 20,
+    });
+    DummyPointerEvent.emit(base, "wheel", { deltaY: 1 });
+    expect(stepBar.value).toBe(10);
+  });
+
+  it("should increase value on wheel down", () => {
+    const stepBar = new StepBarView({
+      ...getDefaultValue(),
+      initialValue: 20,
+    });
+    DummyPointerEvent.emit(base, "wheel", { deltaY: -1 });
+    expect(stepBar.value).toBe(30);
+  });
+
+  it("should not change value when wheel event is not vertical", () => {
+    const stepBar = new StepBarView({
+      ...getDefaultValue(),
+      initialValue: 20,
+    });
+    DummyPointerEvent.emit(base, "wheel", { deltaX: 1 });
+    expect(stepBar.value).toBe(20);
+    DummyPointerEvent.emit(base, "wheel", { deltaY: 0 });
+    expect(stepBar.value).toBe(20);
+  });
+
+  it("should increase value on wheel up with horizontal orientation", () => {
+    const stepBar = new StepBarView({
+      ...getDefaultValue(),
+      isHorizontal: true,
+      initialValue: 20,
+    });
+    DummyPointerEvent.emit(base, "wheel", { deltaY: -1 });
+    expect(stepBar.value).toBe(30);
+  });
+
+  it("should decrease value on wheel down with horizontal orientation", () => {
+    const stepBar = new StepBarView({
+      ...getDefaultValue(),
+      isHorizontal: true,
+      initialValue: 30,
+    });
+    DummyPointerEvent.emit(base, "wheel", { deltaY: 1 });
+    expect(stepBar.value).toBe(20);
   });
 });

--- a/__test__/StepBarView.spec.ts
+++ b/__test__/StepBarView.spec.ts
@@ -454,4 +454,16 @@ describe("StepBarView wheel", () => {
     DummyPointerEvent.emit(base, "wheel", wheelDown);
     expect(stepBar.value).toBe(20);
   });
+
+  it("should initialize with mousewheel disabled when enableMouseWheel is false", () => {
+    const stepBar = new StepBarView({
+      ...getDefaultValue(),
+      initialValue: 20,
+      enableMouseWheel: false,
+    });
+    DummyPointerEvent.emit(base, "wheel", wheelUp);
+    expect(stepBar.value).toBe(20);
+    DummyPointerEvent.emit(base, "wheel", wheelDown);
+    expect(stepBar.value).toBe(20);
+  });
 });

--- a/__test__/StepBarView.spec.ts
+++ b/__test__/StepBarView.spec.ts
@@ -338,9 +338,31 @@ describe("StepBarView wheel", () => {
     expect(stepBar.value).toBe(10);
   });
 
+  it("should decrease value on wheel up", () => {
+    const stepBar = new StepBarView({
+      ...getDefaultValue(),
+      sliderStartPoint: 100,
+      sliderMaxPoint: 0,
+      initialValue: 20,
+    });
+    DummyPointerEvent.emit(base, "wheel", { deltaY: 1 });
+    expect(stepBar.value).toBe(10);
+  });
+
   it("should increase value on wheel down", () => {
     const stepBar = new StepBarView({
       ...getDefaultValue(),
+      initialValue: 20,
+    });
+    DummyPointerEvent.emit(base, "wheel", { deltaY: -1 });
+    expect(stepBar.value).toBe(30);
+  });
+
+  it("should decrease value on wheel down", () => {
+    const stepBar = new StepBarView({
+      ...getDefaultValue(),
+      sliderStartPoint: 100,
+      sliderMaxPoint: 0,
       initialValue: 20,
     });
     DummyPointerEvent.emit(base, "wheel", { deltaY: -1 });
@@ -358,23 +380,23 @@ describe("StepBarView wheel", () => {
     expect(stepBar.value).toBe(20);
   });
 
-  it("should increase value on wheel up with horizontal orientation", () => {
+  it("should decrease value on wheel up with vertical orientation", () => {
     const stepBar = new StepBarView({
       ...getDefaultValue(),
-      isHorizontal: true,
+      isHorizontal: false,
       initialValue: 20,
     });
     DummyPointerEvent.emit(base, "wheel", { deltaY: -1 });
-    expect(stepBar.value).toBe(30);
+    expect(stepBar.value).toBe(10);
   });
 
-  it("should decrease value on wheel down with horizontal orientation", () => {
+  it("should increase value on wheel down with vertical orientation", () => {
     const stepBar = new StepBarView({
       ...getDefaultValue(),
-      isHorizontal: true,
-      initialValue: 30,
+      isHorizontal: false,
+      initialValue: 20,
     });
     DummyPointerEvent.emit(base, "wheel", { deltaY: 1 });
-    expect(stepBar.value).toBe(20);
+    expect(stepBar.value).toBe(30);
   });
 });

--- a/__test__/StepBarView.spec.ts
+++ b/__test__/StepBarView.spec.ts
@@ -426,4 +426,32 @@ describe("StepBarView wheel", () => {
     DummyPointerEvent.emit(base, "wheel", wheelDown);
     expect(stepBar.value).toBe(10);
   });
+
+  it("should not respond to wheel events when disabled", () => {
+    const stepBar = new StepBarView({
+      ...getDefaultValue(),
+      initialValue: 20,
+    });
+    stepBar.disableWheel();
+    DummyPointerEvent.emit(base, "wheel", wheelUp);
+    expect(stepBar.value).toBe(20);
+    DummyPointerEvent.emit(base, "wheel", wheelDown);
+    expect(stepBar.value).toBe(20);
+  });
+
+  it("should respond to wheel events after re-enabling", () => {
+    const stepBar = new StepBarView({
+      ...getDefaultValue(),
+      initialValue: 20,
+    });
+    stepBar.disableWheel();
+    DummyPointerEvent.emit(base, "wheel", wheelUp);
+    expect(stepBar.value).toBe(20);
+
+    stepBar.enableWheel();
+    DummyPointerEvent.emit(base, "wheel", wheelUp);
+    expect(stepBar.value).toBe(30);
+    DummyPointerEvent.emit(base, "wheel", wheelDown);
+    expect(stepBar.value).toBe(20);
+  });
 });

--- a/__test__/StepBarView.spec.ts
+++ b/__test__/StepBarView.spec.ts
@@ -329,33 +329,36 @@ describe("StepBarView wheel", () => {
     };
   };
 
-  it("should decrease value on wheel up", () => {
+  const wheelUp = { deltaY: -1 };
+  const wheelDown = { deltaY: 1 };
+
+  it("should increase value on wheel up", () => {
     const stepBar = new StepBarView({
       ...getDefaultValue(),
       initialValue: 20,
     });
-    DummyPointerEvent.emit(base, "wheel", { deltaY: 1 });
-    expect(stepBar.value).toBe(10);
+    DummyPointerEvent.emit(base, "wheel", wheelUp);
+    expect(stepBar.value).toBe(30);
   });
 
-  it("should decrease value on wheel up", () => {
+  it("should increase value on wheel up", () => {
     const stepBar = new StepBarView({
       ...getDefaultValue(),
       sliderStartPoint: 100,
       sliderMaxPoint: 0,
       initialValue: 20,
     });
-    DummyPointerEvent.emit(base, "wheel", { deltaY: 1 });
-    expect(stepBar.value).toBe(10);
+    DummyPointerEvent.emit(base, "wheel", wheelUp);
+    expect(stepBar.value).toBe(30);
   });
 
-  it("should increase value on wheel down", () => {
+  it("should decrease value on wheel down", () => {
     const stepBar = new StepBarView({
       ...getDefaultValue(),
       initialValue: 20,
     });
-    DummyPointerEvent.emit(base, "wheel", { deltaY: -1 });
-    expect(stepBar.value).toBe(30);
+    DummyPointerEvent.emit(base, "wheel", wheelDown);
+    expect(stepBar.value).toBe(10);
   });
 
   it("should decrease value on wheel down", () => {
@@ -365,8 +368,8 @@ describe("StepBarView wheel", () => {
       sliderMaxPoint: 0,
       initialValue: 20,
     });
-    DummyPointerEvent.emit(base, "wheel", { deltaY: -1 });
-    expect(stepBar.value).toBe(30);
+    DummyPointerEvent.emit(base, "wheel", wheelDown);
+    expect(stepBar.value).toBe(10);
   });
 
   it("should not change value when wheel event is not vertical", () => {
@@ -386,7 +389,7 @@ describe("StepBarView wheel", () => {
       isHorizontal: false,
       initialValue: 20,
     });
-    DummyPointerEvent.emit(base, "wheel", { deltaY: -1 });
+    DummyPointerEvent.emit(base, "wheel", wheelUp);
     expect(stepBar.value).toBe(10);
   });
 
@@ -395,8 +398,32 @@ describe("StepBarView wheel", () => {
       ...getDefaultValue(),
       isHorizontal: false,
       initialValue: 20,
+      sliderStartPoint: 100,
+      sliderMaxPoint: 0,
     });
-    DummyPointerEvent.emit(base, "wheel", { deltaY: 1 });
+    DummyPointerEvent.emit(base, "wheel", wheelUp);
     expect(stepBar.value).toBe(30);
+  });
+
+  it("should increase value on wheel down with vertical orientation", () => {
+    const stepBar = new StepBarView({
+      ...getDefaultValue(),
+      isHorizontal: false,
+      initialValue: 20,
+    });
+    DummyPointerEvent.emit(base, "wheel", wheelDown);
+    expect(stepBar.value).toBe(30);
+  });
+
+  it("should increase value on wheel down with vertical orientation", () => {
+    const stepBar = new StepBarView({
+      ...getDefaultValue(),
+      isHorizontal: false,
+      sliderStartPoint: 100,
+      sliderMaxPoint: 0,
+      initialValue: 20,
+    });
+    DummyPointerEvent.emit(base, "wheel", wheelDown);
+    expect(stepBar.value).toBe(10);
   });
 });

--- a/demoSrc/demo_stepbar_vertical.js
+++ b/demoSrc/demo_stepbar_vertical.js
@@ -37,8 +37,8 @@ const initStepBar = (stage, view) => {
 
   const stepBar = new StepBarView({
     base,
-    sliderStartPoint: SLIDER_X + SLIDER_H,
-    sliderMaxPoint: SLIDER_X,
+    sliderStartPoint: SLIDER_X,
+    sliderMaxPoint: SLIDER_X + SLIDER_H,
     minValue: 0,
     maxValue: 10,
     step: 1,

--- a/demoSrc/demo_stepbar_vertical.js
+++ b/demoSrc/demo_stepbar_vertical.js
@@ -37,8 +37,8 @@ const initStepBar = (stage, view) => {
 
   const stepBar = new StepBarView({
     base,
-    sliderStartPoint: SLIDER_X,
-    sliderMaxPoint: SLIDER_X + SLIDER_H,
+    sliderStartPoint: SLIDER_X + SLIDER_H,
+    sliderMaxPoint: SLIDER_X,
     minValue: 0,
     maxValue: 10,
     step: 1,

--- a/src/stepBar/StepBarOption.ts
+++ b/src/stepBar/StepBarOption.ts
@@ -36,6 +36,11 @@ export interface StepBarOption {
   decrementButton?: Container;
   isHorizontal?: boolean;
   canvas?: HTMLCanvasElement;
+  /**
+   * Whether to enable mouse wheel operation.
+   * @default true
+   */
+  enableMouseWheel?: boolean;
 }
 
 /**
@@ -51,6 +56,7 @@ export interface InitializedStepBarOption extends StepBarOption {
   minValue: number;
   isHorizontal: boolean;
   initialValue: number;
+  enableMouseWheel: boolean;
 }
 
 /**
@@ -67,5 +73,6 @@ export function initializeStepBarOption(
     minValue: option.minValue ?? 0,
     step: option.step ?? 1,
     isHorizontal: option.isHorizontal ?? true,
+    enableMouseWheel: option.enableMouseWheel ?? true,
   };
 }

--- a/src/stepBar/StepBarView.ts
+++ b/src/stepBar/StepBarView.ts
@@ -306,11 +306,14 @@ export class StepBarView extends Container {
     if (e.deltaY === 0 || e.deltaY === undefined) return;
 
     const { isHorizontal, sliderStartPoint, sliderMaxPoint } = this.option;
-    const isPositiveDelta = e.deltaY > 0;
-    const isNormalDirection = sliderStartPoint < sliderMaxPoint;
 
-    const shouldIncrement =
-      (isPositiveDelta !== !isHorizontal) !== isNormalDirection;
-    shouldIncrement ? this.incrementValue() : this.decrementValue();
+    const isPositiveDelta = e.deltaY > 0;
+    if (isHorizontal) {
+      isPositiveDelta ? this.decrementValue() : this.incrementValue();
+    } else {
+      const isNormalDirection = sliderStartPoint < sliderMaxPoint;
+      const shouldIncrement = isPositiveDelta === isNormalDirection;
+      shouldIncrement ? this.incrementValue() : this.decrementValue();
+    }
   };
 }

--- a/src/stepBar/StepBarView.ts
+++ b/src/stepBar/StepBarView.ts
@@ -57,7 +57,9 @@ export class StepBarView extends Container {
     this.initSliderButton();
     this.initStepButtons();
     this.initBaseEventHandlers();
-    this.enableWheel();
+    if (this.option.enableMouseWheel) {
+      this.enableWheel();
+    }
   }
 
   /**

--- a/src/stepBar/StepBarView.ts
+++ b/src/stepBar/StepBarView.ts
@@ -303,6 +303,8 @@ export class StepBarView extends Container {
   }
 
   private wheelHandler = (e: WheelEvent): void => {
+    if (e.deltaY === 0 || e.deltaY === undefined) return;
+
     const { isHorizontal, sliderStartPoint, sliderMaxPoint } = this.option;
     const isPositiveDelta = e.deltaY > 0;
     const isNormalDirection = sliderStartPoint < sliderMaxPoint;

--- a/src/stepBar/StepBarView.ts
+++ b/src/stepBar/StepBarView.ts
@@ -57,6 +57,7 @@ export class StepBarView extends Container {
     this.initSliderButton();
     this.initStepButtons();
     this.initBaseEventHandlers();
+    this.enableWheel();
   }
 
   /**
@@ -270,5 +271,44 @@ export class StepBarView extends Container {
       this.option;
     const rate = (this.value - minValue) / (maxValue - minValue);
     return sliderStartPoint + (sliderMaxPoint - sliderStartPoint) * rate;
+  };
+
+  private _isWheelEnabled: boolean = false;
+  /**
+   * マウスホイール操作の有効/無効を取得します。
+   */
+  get isWheelEnabled(): boolean {
+    return this._isWheelEnabled;
+  }
+
+  /**
+   * マウスホイール操作を有効化します。
+   */
+  public enableWheel(): void {
+    if (this._isWheelEnabled) return;
+    const { base } = this.option;
+    base.eventMode = "static";
+    base.on("wheel", this.wheelHandler);
+    this._isWheelEnabled = true;
+  }
+
+  /**
+   * マウスホイール操作を無効化します。
+   */
+  public disableWheel(): void {
+    if (!this._isWheelEnabled) return;
+    const { base } = this.option;
+    base.off("wheel", this.wheelHandler);
+    this._isWheelEnabled = false;
+  }
+
+  private wheelHandler = (e: WheelEvent): void => {
+    const { isHorizontal, sliderStartPoint, sliderMaxPoint } = this.option;
+    const isPositiveDelta = e.deltaY > 0;
+    const isNormalDirection = sliderStartPoint < sliderMaxPoint;
+
+    const shouldIncrement =
+      (isPositiveDelta !== !isHorizontal) !== isNormalDirection;
+    shouldIncrement ? this.incrementValue() : this.decrementValue();
   };
 }


### PR DESCRIPTION
## Feature Addition

Added enableMouseWheel option to StepBarOption
Default value: true

Controls whether mouse wheel operations are enabled
Implementation Details
src/stepBar/StepBarOption.ts

Added enableMouseWheel property to StepBarOption interface
Added enableMouseWheel property to InitializedStepBarOption
Set default value (true) in initializeStepBarOption function
src/stepBar/StepBarView.ts

Modified init() method to control mouse wheel initialization based on enableMouseWheel option

## Test Coverage

Added new test cases to __test__/StepBarView.spec.ts
Test mouse wheel disabled state when initialized with enableMouseWheel: false
Test default behavior (enabled) when initialized without explicit option

## Related Issues
None