### PR TITLE
[Documentation] Git diffコマンドの実行待機を解消

### DIFF
--- a/.clinerules/PULL_REQUEST.md
+++ b/.clinerules/PULL_REQUEST.md
@@ -99,7 +99,7 @@ git branch --show-current
 git log main...HEAD --pretty=format:"Commit: %H%nSubject: %s%nBody: %b" --name-status
 
 # 詳細な差分を確認
-git diff main...HEAD
+git --no-pager diff main...HEAD
 ```
 
 これらの情報を使用して：
@@ -270,3 +270,7 @@ git push origin <branch-name>
 - 特別な注意が必要な実装箇所
 - レビュー時の確認ポイント
 - 上記の必須項目では説明しきれない補足情報がある場合は、ここに記載する
+
+#### 3.3 PRの作成
+
+手順3.2で作成されたPR説明文を元に、ghコマンドでPRを作成します。


### PR DESCRIPTION
## 変更の目的

Git diffコマンド実行後の待機状態が発生しないように改善します。これにより、コマンド実行後すぐに次の操作に移れるようになります。

## 変更の種類

- ドキュメント更新
  - PRルールファイルのGitコマンド部分の更新

## 影響度

Patch - ドキュメントの更新のみで、コードへの影響はありません。

## 変更の概要

- git diffコマンドに--no-pagerオプションを追加
  - 変更前: `git diff main...HEAD`
  - 変更後: `git --no-pager diff main...HEAD`
  - 効果: コマンド実行後の待機状態をスキップし、即座に次の操作に移行可能