### PR TITLE
feat: Add refreshAfterContentsResize method to ScrollBarView

### DIFF
--- a/__test__/ScrollBarView.spec.ts
+++ b/__test__/ScrollBarView.spec.ts
@@ -1,4 +1,4 @@
-import { Ticker } from "pixi.js";
+import { Graphics, Rectangle, Ticker } from "pixi.js";
 import {
   afterAll,
   afterEach,
@@ -210,6 +210,83 @@ describe("ScrollBarView", () => {
       updateTicker(16 * 5);
       expect(scrollbar.rate).toBeCloseTo(2.519);
       expect(inertial.speed).toBe(0);
+    });
+  });
+
+  describe("refreshAfterContentsResize", () => {
+    test("コンテンツエリアがマスク以下の場合、先頭位置に配置される", () => {
+      const W = 100;
+      const H = 100;
+      const SCROLL_BAR_W = 16;
+      // コンテンツがマスクより大きい初期状態
+      const CONTENTS_SCALE = 2.0;
+      const { scrollBarContents, scrollbar } =
+        ScrollBarViewGenerator.generateScrollBarSet(
+          W,
+          H,
+          SCROLL_BAR_W,
+          CONTENTS_SCALE,
+          "TestScrollBar_refreshAfterContentsResize_small",
+        );
+
+      scrollbar.changeRate(0.5); // 中間位置に設定
+
+      // コンテンツを縮小
+      const container = scrollBarContents.target;
+      container.hitArea = new Rectangle(0, 0, W, H * 0.5);
+      scrollbar.refreshAfterContentsResize();
+
+      expect(scrollbar.contents.target.y).toBeCloseTo(0.0); // 先頭位置に配置される
+    });
+
+    test("マスク以上かつ中間位置の場合、スクロール位置が維持される", () => {
+      const W = 100;
+      const H = 100;
+      const SCROLL_BAR_W = 16;
+      const CONTENTS_SCALE = 2.0;
+      const { scrollBarContents, scrollbar } =
+        ScrollBarViewGenerator.generateScrollBarSet(
+          W,
+          H,
+          SCROLL_BAR_W,
+          CONTENTS_SCALE,
+          "TestScrollBar_refreshAfterContentsResize_middle",
+        );
+
+      scrollbar.changeRate(0.5); // 中間位置に設定
+      const containerPosition = scrollBarContents.target.y;
+
+      // コンテンツサイズを変更（ただし表示範囲を超えたまま）
+      const container = scrollBarContents.target;
+      container.hitArea = new Rectangle(0, 0, W, H * 1.8);
+
+      scrollbar.refreshAfterContentsResize();
+      expect(scrollBarContents.target.y).toBeCloseTo(containerPosition); // 位置が維持される
+    });
+
+    test("マスク以上で下端を超える場合、後端に配置される", () => {
+      const W = 100;
+      const H = 100;
+      const SCROLL_BAR_W = 16;
+      const CONTENTS_SCALE = 2.0;
+      const { scrollBarContents, scrollbar } =
+        ScrollBarViewGenerator.generateScrollBarSet(
+          W,
+          H,
+          SCROLL_BAR_W,
+          CONTENTS_SCALE,
+          "TestScrollBar_refreshAfterContentsResize_exceed",
+        );
+
+      scrollbar.changeRate(1.0); // 末尾位置に設定
+
+      // コンテンツを縮小（現在位置が末尾を超えるように）
+      const container = scrollBarContents.target;
+      container.hitArea = new Rectangle(0, 0, W, H * 1.2);
+      container.boundsArea = new Rectangle(0, 0, W, H * 1.2);
+
+      scrollbar.refreshAfterContentsResize();
+      expect(scrollbar.rate).toBe(1.0); // 末尾位置に配置される
     });
   });
 

--- a/demoSrc/demo_scrollbar.js
+++ b/demoSrc/demo_scrollbar.js
@@ -3,7 +3,6 @@ import {
   Container,
   Graphics,
   Rectangle,
-  Ticker,
   sayHello,
   RendererType,
 } from "pixi.js";
@@ -27,10 +26,8 @@ const onDomContentsLoaded = async () => {
   const btnPlus = addButton("Contents Size +");
   const btnMinus = addButton("Contents Size -");
   const changeSize = (dif) => {
-    const scrollPosition = scrollbar.rate;
     overrideContents(base, scrollbar.contents.target, dif);
-    scrollbar.updateSlider();
-    scrollbar.changeRate(scrollPosition);
+    scrollbar.refreshAfterContentsResize();
   };
 
   const onPlus = () => {
@@ -124,9 +121,6 @@ const getScrollBarContents = (w, h, container, fillStyle) => {
  */
 const overrideContents = (g, container, difHeight) => {
   const fill = g.fillStyle;
-  console.log(g);
-  console.log(fill);
-
   const area = container.hitArea.clone();
   area.height += difHeight;
 

--- a/src/scrollBar/ScrollBarView.ts
+++ b/src/scrollBar/ScrollBarView.ts
@@ -210,6 +210,45 @@ export class ScrollBarView extends SliderView {
     this.scrollBarEventEmitter.emit("stop_inertial_tween");
   }
 
+  /**
+   * Refresh the scrollbar and content position after the scroll contents have been resized.
+   *
+   * When the content size is changed, the following update process must be performed in order:
+   * 1. Save the current scroll position
+   * 2. Update the scrollbar size and position
+   * 3. Restore the scroll position
+   *
+   * Note: The scroll position will be automatically adjusted to valid range by changeRate.
+   * - If content size <= mask size: Will be set to start position (rate = 0)
+   * - If content size > mask size:
+   *   - Will maintain position if within valid range
+   *   - Will adjust to end if position exceeds the end
+   *
+   * スクロールコンテンツのサイズが変更された後に、スクロールバーとコンテンツ位置をリフレッシュする
+   *
+   * コンテンツのサイズを変更した場合、以下の順序で更新処理を行う必要があります：
+   * 1. 現在のスクロール位置を一時保存
+   * 2. スクロールバーのサイズと位置を更新
+   * 3. スクロール位置を再設定
+   *
+   * 注意：スクロール位置は changeRate によって自動的に有効範囲に調整されます。
+   * - コンテンツサイズ <= マスクサイズの場合：先頭位置になります（rate = 0）
+   * - コンテンツサイズ > マスクサイズの場合：
+   *   - 有効範囲内なら位置を維持
+   *   - 範囲外なら末尾に自動調整
+   */
+  public refreshAfterContentsResize(): void {
+    const currentY = this.contents.target.y;
+    this.updateSlider();
+    ScrollBarViewUtil.clampTargetPosition(
+      this.contents.target,
+      this.contents.mask,
+      currentY,
+      this.isHorizontal,
+    );
+    this.updateSliderPosition();
+  }
+
   protected override onDisposeFunction(): void {
     this.contents.dispose();
     this.inertialManager.dispose();


### PR DESCRIPTION
# コンテンツサイズ変更後のリフレッシュ機能を追加

ScrollBarViewにrefreshAfterContentsResizeメソッドを追加し、コンテンツサイズ変更時の挙動を改善しました。

## 変更内容

- ScrollBarViewに`refreshAfterContentsResize`メソッドを追加
- スクロールコンテンツのリサイズ処理を整理
- コンテンツサイズに応じた適切なスクロール位置の調整機能を実装

## 実装の詳細

1. コンテンツ位置の調整
   - `ScrollBarViewUtil.clampTargetPosition`を使用してコンテンツを適切な範囲内に収める
   - マスクサイズより小さい場合は先頭位置（y=0）に自動調整
   - マスクサイズより大きい場合は可能な限り現在位置を維持

2. テストケースの追加
   - コンテンツエリアがマスク以下の場合の位置調整
   - マスク以上かつ中間位置の場合の位置維持
   - マスク以上で下端を超える場合の位置調整

3. デモの改善
   - コンテンツサイズ変更時の処理を簡素化
   - 使用例を追加

## 影響範囲

- Minor Change（既存の動作は維持）
- 既存のAPIには影響なし